### PR TITLE
Bump `Tested up to` Tag to Show Support for WordPress v6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contributors: [vikings412](https://profiles.wordpress.org/vikings412/) <br>
 Donate Link: https://paypal.me/michaelw13 <br>
 Tags: events, customization, modern-tribe, override, template <br>
 Requires at least: 5.0 <br>
-Tested up to: 5.9 <br>
+Tested up to: 6.0 <br>
 Stable tag: 4.0.0 <br>
 Requires PHP: 7.0.0 <br>
 License: GPLv2 or later <br>


### PR DESCRIPTION
The plugin has been tested with the RC2 for WordPress v6.0. 

No anomalies were discovered with the `Display Event Location for The Events Calendar` plugin. The events calendar was able to display both venue names without the street address and the venue name with the street address.