### PR TITLE
Bump Support for WP 6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contributors: [vikings412](https://profiles.wordpress.org/vikings412/) <br>
 Donate Link: https://paypal.me/michaelw13 <br>
 Tags: events, customization, modern-tribe, override, template <br>
 Requires at least: 5.0.0 <br>
-Tested up to: 6.6.0 <br>
+Tested up to: 6.7.0 <br>
 Stable tag: 4.4.0 <br>
 Requires PHP: 7.0.0 <br>
 License: GPLv2 or later <br>


### PR DESCRIPTION
Closes: https://github.com/mike-weiner/display-event-locations-tec/issues/36

I've tested support with WordPress 6.7 and The Events Calendar 6.8.1. No issues were found. This PR updates the plugin to show that we fully support this new WP release.