### PR TITLE
Support WordPress `v6.8.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Contributors: [vikings412](https://profiles.wordpress.org/vikings412/) <br>
 Donate Link: https://paypal.me/michaelw13 <br>
 Tags: events, customization, modern-tribe, override, template <br>
 Requires at least: 5.0.0 <br>
-Tested up to: 6.7.1 <br>
+Tested up to: 6.8.0 <br>
 Stable tag: 4.5.0 <br>
 Requires PHP: 7.0.0 <br>
 License: GPLv2 or later <br>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: vikings412
 Donate Link: https://paypal.me/michaelw13
 Tags: events, customization, modern-tribe, override, template
 Requires at least: 5.0.0
-Tested up to: 6.7.1
+Tested up to: 6.8.0
 Stable tag: 4.5.0
 Requires PHP: 7.0.0
 License: GPLv2 or later


### PR DESCRIPTION
Related to https://github.com/mike-weiner/display-event-locations-tec/issues/40

This PR updates the `Tested up to` tag in the `README` to reflect that this plugin is compatible with WordPress `v6.8.0`.