### PR TITLE
Confirm Support for WordPress v6.9 and Bump Plugin Version for v4.6.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Contributors: [vikings412](https://profiles.wordpress.org/vikings412/) <br>
 Donate Link: https://paypal.me/michaelw13 <br>
 Tags: events, customization, modern-tribe, override, template <br>
 Requires at least: 5.0.0 <br>
-Tested up to: 6.8 <br>
-Stable tag: 4.5.0 <br>
+Tested up to: 6.9 <br>
+Stable tag: 4.6.0 <br>
 Requires PHP: 7.0.0 <br>
 License: GPLv2 or later <br>
 License URI: https://www.gnu.org/licenses/gpl-2.0.html <br>
@@ -123,6 +123,14 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 5. This is what the tooltip for a featured event will look like after activating this plugin with both the location name and street address enabled in the tooltip.
 
 ## Changelog
+
+### 4.6.0
+* Released on Sunday, November 23, 2025
+* Fixed logic to correctly provide safe default values for settings on plugin install.
+* Support for WordPress v6.9+ has been confirmed.
+* Edited: `display-event-locations-tec.php`
+* Edited: `README.md`
+* Edited: `tribe-templates/month/tooltip-venue.php`
 
 ### 4.5.0
 * Released on Wednesday, December 25, 2024
@@ -415,6 +423,9 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 * Initial release.
 
 ## Upgrade Notice
+
+### 4.6.0
+Version 4.6.0 is a recommended, minor update that contains a bug fix. Support for WordPress v6.9+ has been confirmed. Read the changelog for more details.
 
 ### 4.5.0
 Version 4.5.0 is a recommended, minor update. Support for WordPress v6.7.0+ has been confirmed. All WordPress Plugin Check warnings have been resolved. Read the changelog for more details.

--- a/display-event-locations-tec.php
+++ b/display-event-locations-tec.php
@@ -5,7 +5,7 @@
  * Requires Plugins: the-events-calendar
  * Plugin URI: https://michaelweiner.org/
  * Description: Display an event's venue (location) in the tooltip of the monthly calendar view when using The Events Calendar or The Events Calendar Pro.
- * Version: 4.5.0
+ * Version: 4.6.0
  * Requires at least: 5.0.0
  * Requires PHP: 7.0.0
  * Author: Michael Weiner

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: vikings412
 Donate Link: https://paypal.me/michaelw13
 Tags: events, customization, modern-tribe, override, template
 Requires at least: 5.0.0
-Tested up to: 6.8
-Stable tag: 4.5.0
+Tested up to: 6.9
+Stable tag: 4.6.0
 Requires PHP: 7.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -116,6 +116,14 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 5. This is what the tooltip for a featured event will look like after activating this plugin with both the location name and street address enabled in the tooltip.
 
 == Changelog ==
+
+= 4.6.0 =
+* Released on Sunday, November 23, 2025
+* Fixed logic to correctly provide safe default values for settings on plugin install.
+* Support for WordPress v6.9+ has been confirmed.
+* Edited: `display-event-locations-tec.php`
+* Edited: `README.md`
+* Edited: `tribe-templates/month/tooltip-venue.php`
 
 = 4.5.0 =
 * Released on Wednesday, December 25, 2024
@@ -408,6 +416,9 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 * Initial release.
 
 == Upgrade Notice ==
+
+= 4.6.0 =
+Version 4.6.0 is a recommended, minor update that contains a bug fix. Support for WordPress v6.9+ has been confirmed. Read the changelog for more details.
 
 = 4.5.0 =
 Version 4.5.0 is a recommended, minor update. Support for WordPress v6.7.0+ has been confirmed. All WordPress Plugin Check warnings have been resolved. Read the changelog for more details.


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/display-event-locations-tec/issues/48

This PR: 

- Bumps DELTEC's version in preparation for a minor patch release.
- Bumps DELTEC's `README` to include support for WordPress v6.9 that is due for release in early December. Testing was done with WP v6.9-RC2.