### PR TITLE
Confirm support for WP v7.0; Bump plugin version

### DIFF
--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -18,6 +18,8 @@ jobs:
         php-version: latest
         coverage: none
         tools: wp-cli
+    - name: Update WP-CLI to latest
+      run: wp cli update --yes --allow-root
     - name: Install latest version of dist-archive-command
       run: wp package install wp-cli/dist-archive-command:@stable
     - name: Build plugin

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -17,9 +17,7 @@ jobs:
       with:
         php-version: latest
         coverage: none
-        tools: wp-cli
-    - name: Update WP-CLI to latest
-      run: wp cli update --yes --allow-root
+        tools: wp-cli:2.13.0
     - name: Install latest version of dist-archive-command
       run: wp package install wp-cli/dist-archive-command:@stable
     - name: Build plugin

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -19,7 +19,9 @@ jobs:
         coverage: none
         tools: wp-cli
     - name: Install latest version of dist-archive-command
-      run: wp package install wp-cli/dist-archive-command
+      # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
+      # Revisit when wp-cli >2.12.0 is available: https://github.com/wp-cli/wp-cli/releases
+      run: wp package install wp-cli/dist-archive-command:@v3.1.0
     - name: Build plugin
       run: |
         wp dist-archive . ./display-event-locations-tec.zip

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -17,9 +17,9 @@ jobs:
       with:
         php-version: latest
         coverage: none
-        tools: wp-cli:2.13.0
+        tools: wp-cli
     - name: Install latest version of dist-archive-command
-      run: wp package install wp-cli/dist-archive-command:@stable
+      run: wp package install wp-cli/dist-archive-command
     - name: Build plugin
       run: |
         wp dist-archive . ./display-event-locations-tec.zip

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install latest version of dist-archive-command
       # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
       # Revisit when wp-cli >2.12.0 is available: https://github.com/wp-cli/wp-cli/releases
-      run: wp package install wp-cli/dist-archive-command:@v3.1.0
+      run: wp package install wp-cli/dist-archive-command:v3.1.0
     - name: Build plugin
       run: |
         wp dist-archive . ./display-event-locations-tec.zip

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Contributors: [vikings412](https://profiles.wordpress.org/vikings412/) <br>
 Donate Link: https://paypal.me/michaelw13 <br>
 Tags: events, customization, modern-tribe, override, template <br>
 Requires at least: 5.0.0 <br>
-Tested up to: 6.9 <br>
-Stable tag: 4.6.0 <br>
+Tested up to: 7.0 <br>
+Stable tag: 4.7.0 <br>
 Requires PHP: 7.0.0 <br>
 License: GPLv2 or later <br>
 License URI: https://www.gnu.org/licenses/gpl-2.0.html <br>
@@ -123,6 +123,12 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 5. This is what the tooltip for a featured event will look like after activating this plugin with both the location name and street address enabled in the tooltip.
 
 ## Changelog
+
+### 4.7.0
+* Released on Wednesday, May 20, 2026
+* Support for WordPress v7.0+ has been confirmed.
+* Edited: `display-event-locations-tec.php`
+* Edited: `README.md`
 
 ### 4.6.0
 * Released on Sunday, November 23, 2025
@@ -423,6 +429,9 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 * Initial release.
 
 ## Upgrade Notice
+
+### 4.7.0
+Version 4.7.0 is a recommended, minor update. Support for WordPress v7.0+ has been confirmed. Read the changelog for more details.
 
 ### 4.6.0
 Version 4.6.0 is a recommended, minor update that contains a bug fix. Support for WordPress v6.9+ has been confirmed. Read the changelog for more details.

--- a/display-event-locations-tec.php
+++ b/display-event-locations-tec.php
@@ -5,7 +5,7 @@
  * Requires Plugins: the-events-calendar
  * Plugin URI: https://michaelweiner.org/
  * Description: Display an event's venue (location) in the tooltip of the monthly calendar view when using The Events Calendar or The Events Calendar Pro.
- * Version: 4.6.0
+ * Version: 4.7.0
  * Requires at least: 5.0.0
  * Requires PHP: 7.0.0
  * Author: Michael Weiner

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: vikings412
 Donate Link: https://paypal.me/michaelw13
 Tags: events, customization, modern-tribe, override, template
 Requires at least: 5.0.0
-Tested up to: 6.9
-Stable tag: 4.6.0
+Tested up to: 7.0
+Stable tag: 4.7.0
 Requires PHP: 7.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -116,6 +116,12 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 5. This is what the tooltip for a featured event will look like after activating this plugin with both the location name and street address enabled in the tooltip.
 
 == Changelog ==
+
+= 4.7.0 =
+* Released on Wednesday, May 20, 2026
+* Support for WordPress v7.0+ has been confirmed.
+* Edited: `display-event-locations-tec.php`
+* Edited: `README.md`
 
 = 4.6.0 =
 * Released on Sunday, November 23, 2025
@@ -416,6 +422,9 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 * Initial release.
 
 == Upgrade Notice ==
+
+= 4.7.0 =
+Version 4.7.0 is a recommended, minor update. Support for WordPress v7.0+ has been confirmed. Read the changelog for more details.
 
 = 4.6.0 =
 Version 4.6.0 is a recommended, minor update that contains a bug fix. Support for WordPress v6.9+ has been confirmed. Read the changelog for more details.

--- a/tribe-templates/month/tooltip-venue.php
+++ b/tribe-templates/month/tooltip-venue.php
@@ -1,5 +1,7 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) exit;
+
 $deltec_options = get_option('deltec_options', []);
 
 $deltec_tooltip_message = $deltec_options['pre-venue-message'] ?? 'Location:';


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/display-event-locations-tec/issues/50

This PR: 

- Bumps DELTEC's version in preparation for a minor patch release.
- Bumps DELTEC's `README` to include support for WordPress v7.0 that is due for release in early December. Testing was done with WP v7.0.