### PR TITLE
Confirm support for WP v7.1; Bump plugin version

### DIFF
--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -19,7 +19,9 @@ jobs:
         coverage: none
         tools: wp-cli
     - name: Install latest version of dist-archive-command
-      run: wp package install wp-cli/dist-archive-command:@stable
+      # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
+      # Revisit when wp-cli >2.12.0 is available: https://github.com/wp-cli/wp-cli/releases
+      run: wp package install wp-cli/dist-archive-command:v3.1.0
     - name: Build plugin
       run: |
         wp dist-archive . ./display-event-locations-tec.zip

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           php-version: latest
           coverage: none
-          tools: wp-cli, composer:v2.9.8
+          tools: wp-cli:latest, composer:v2.9.8
       - name: Install latest version of dist-archive-command
         run: wp package install wp-cli/dist-archive-command:@stable
       - name: Build plugin

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -18,9 +18,11 @@ jobs:
           php-version: latest
           coverage: none
           tools: wp-cli, composer:v2.9.8
-      - name: Install latest version of dist-archive-command
-        # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
-        # Revisit when wp-cli >2.13.0 is available: https://github.com/wp-cli/wp-cli/releases
+      - name: Install dist-archive-command
+        env:
+          GITHUB_TOKEN: ""
+          GH_TOKEN: ""
+          COMPOSER_AUTH: ""
         run: wp package install wp-cli/dist-archive-command:v3.1.0
       - name: Build plugin
         run: |

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -19,9 +19,9 @@ jobs:
         coverage: none
         tools: wp-cli
     - name: Install latest version of dist-archive-command
-      # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
-      # Revisit when wp-cli >2.12.0 is available: https://github.com/wp-cli/wp-cli/releases
-      run: wp package install wp-cli/dist-archive-command:v3.1.0
+      env:
+        COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
+      run: wp package install wp-cli/dist-archive-command:@stable
     - name: Build plugin
       run: |
         wp dist-archive . ./display-event-locations-tec.zip

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -19,9 +19,7 @@ jobs:
         coverage: none
         tools: wp-cli
     - name: Install latest version of dist-archive-command
-      # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
-      # Revisit when wp-cli >2.12.0 is available: https://github.com/wp-cli/wp-cli/releases
-      run: wp package install wp-cli/dist-archive-command:v3.1.0
+      run: wp package install wp-cli/dist-archive-command:@stable
     - name: Build plugin
       run: |
         wp dist-archive . ./display-event-locations-tec.zip

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -17,9 +17,11 @@ jobs:
         with:
           php-version: latest
           coverage: none
-          tools: wp-cli:latest, composer:v2.9.8
+          tools: wp-cli, composer:v2.9.8
       - name: Install latest version of dist-archive-command
-        run: wp package install wp-cli/dist-archive-command:@stable
+        # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
+        # Revisit when wp-cli >2.13.0 is available: https://github.com/wp-cli/wp-cli/releases
+        run: wp package install wp-cli/dist-archive-command:v3.1.0
       - name: Build plugin
         run: |
           wp dist-archive . ./display-event-locations-tec.zip

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,33 +1,31 @@
-name: 'WordPress Plugin Check'
+name: "WordPress Plugin Check"
 
 on:
   pull_request:
   push:
     branches:
-    - main
+      - main
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: latest
-        coverage: none
-        tools: wp-cli
-    - name: Install latest version of dist-archive-command
-      env:
-        COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ github.token }}"}}'
-      run: wp package install wp-cli/dist-archive-command:@stable
-    - name: Build plugin
-      run: |
-        wp dist-archive . ./display-event-locations-tec.zip
-        mkdir tmp-build
-        unzip display-event-locations-tec.zip -d tmp-build
-    - name: Run plugin check
-      uses: wordpress/plugin-check-action@v1
-      with:
-        build-dir: './tmp-build/display-event-locations-tec'
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: latest
+          coverage: none
+          tools: wp-cli, composer:v2.9.8
+      - name: Install latest version of dist-archive-command
+        run: wp package install wp-cli/dist-archive-command:@stable
+      - name: Build plugin
+        run: |
+          wp dist-archive . ./display-event-locations-tec.zip
+          mkdir tmp-build
+          unzip display-event-locations-tec.zip -d tmp-build
+      - name: Run plugin check
+        uses: wordpress/plugin-check-action@v1
+        with:
+          build-dir: "./tmp-build/display-event-locations-tec"

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -18,11 +18,10 @@ jobs:
           php-version: latest
           coverage: none
           tools: wp-cli, composer:v2.9.8
+          github-token: ""
       - name: Install dist-archive-command
-        env:
-          GITHUB_TOKEN: ""
-          GH_TOKEN: ""
-          COMPOSER_AUTH: ""
+        # Pinned to v3.1.0 because v3.2.0+ requires wp-cli ^2.13, which hasn't been released yet.
+        # Revisit when wp-cli >2.12.0 is available: https://github.com/wp-cli/wp-cli/releases
         run: wp package install wp-cli/dist-archive-command:v3.1.0
       - name: Build plugin
         run: |

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Contributors: [vikings412](https://profiles.wordpress.org/vikings412/) <br>
 Donate Link: https://paypal.me/michaelw13 <br>
 Tags: events, customization, modern-tribe, override, template <br>
 Requires at least: 5.0.0 <br>
-Tested up to: 7.0 <br>
-Stable tag: 4.7.0 <br>
+Tested up to: 7.1 <br>
+Stable tag: 4.8.0 <br>
 Requires PHP: 7.0.0 <br>
 License: GPLv2 or later <br>
 License URI: https://www.gnu.org/licenses/gpl-2.0.html <br>
@@ -123,6 +123,12 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 5. This is what the tooltip for a featured event will look like after activating this plugin with both the location name and street address enabled in the tooltip.
 
 ## Changelog
+
+### 4.8.0
+* Released on Sunday, August 16, 2026
+* Support for WordPress v7.1+ has been confirmed.
+* Edited: `display-event-locations-tec.php`
+* Edited: `README.md`
 
 ### 4.7.0
 * Released on Wednesday, May 20, 2026
@@ -429,6 +435,9 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 * Initial release.
 
 ## Upgrade Notice
+
+### 4.8.0
+Version 4.8.0 is a recommended, minor update. Support for WordPress v7.1+ has been confirmed. Read the changelog for more details.
 
 ### 4.7.0
 Version 4.7.0 is a recommended, minor update. Support for WordPress v7.0+ has been confirmed. Read the changelog for more details.

--- a/display-event-locations-tec.php
+++ b/display-event-locations-tec.php
@@ -5,7 +5,7 @@
  * Requires Plugins: the-events-calendar
  * Plugin URI: https://michaelweiner.org/
  * Description: Display an event's venue (location) in the tooltip of the monthly calendar view when using The Events Calendar or The Events Calendar Pro.
- * Version: 4.7.0
+ * Version: 4.8.0
  * Requires at least: 5.0.0
  * Requires PHP: 7.0.0
  * Author: Michael Weiner

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: vikings412
 Donate Link: https://paypal.me/michaelw13
 Tags: events, customization, modern-tribe, override, template
 Requires at least: 5.0.0
-Tested up to: 7.0
-Stable tag: 4.7.0
+Tested up to: 7.1
+Stable tag: 4.8.0
 Requires PHP: 7.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -116,6 +116,12 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 5. This is what the tooltip for a featured event will look like after activating this plugin with both the location name and street address enabled in the tooltip.
 
 == Changelog ==
+
+= 4.8.0 =
+* Released on Sunday, August 16, 2026
+* Support for WordPress v7.1+ has been confirmed.
+* Edited: `display-event-locations-tec.php`
+* Edited: `README.md`
 
 = 4.7.0 =
 * Released on Wednesday, May 20, 2026
@@ -422,6 +428,9 @@ No. As of version `4.0.0` of this plugin, ***only*** the the new calendar views 
 * Initial release.
 
 == Upgrade Notice ==
+
+= 4.8.0 =
+Version 4.8.0 is a recommended, minor update. Support for WordPress v7.1+ has been confirmed. Read the changelog for more details.
 
 = 4.7.0 =
 Version 4.7.0 is a recommended, minor update. Support for WordPress v7.0+ has been confirmed. Read the changelog for more details.


### PR DESCRIPTION
Related to: https://github.com/mike-weiner/display-event-locations-tec/issues/52

This PR: 

- Bumps DELTEC's version in preparation for a minor patch release.
- Bumps DELTEC's `README` to include support for WordPress v7.1 that is due for release in early December. Testing was done with WP v7.1-RC3.